### PR TITLE
DX-516: Pin actions to SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   cancel_previous:
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.12.1
+      - uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
         with:
           workflow_id: ${{ github.event.workflow.id }}
   build-and-test:
@@ -42,7 +42,7 @@ jobs:
   run-e2e-ios:
     runs-on: 'macos-13'
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
+      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: latest-stable
       - name: Install applesimutils
@@ -108,7 +108,7 @@ jobs:
 
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c # v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
           profile: ${{matrix.profile}}
@@ -141,7 +141,7 @@ jobs:
         run: RCT_NO_LAUNCH_PACKAGER=1 yarn e2e build:android
 
       - name: Detox - Test
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c # v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
           profile: ${{matrix.profile}}

--- a/.github/workflows/create_jira.yml
+++ b/.github/workflows/create_jira.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Login
-        uses: atlassian/gajira-login@master
+        uses: atlassian/gajira-login@c22a5debd482401472b285de4f6deedf70ddbb92 # master
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -22,7 +22,7 @@ jobs:
 
       - name: Create
         id: create
-        uses: atlassian/gajira-create@master
+        uses: atlassian/gajira-create@1c54357fdde9dab6273a0e26d67cb175ffffe498 # master
         with:
           project: LIBWEB
           issuetype: Bug


### PR DESCRIPTION
This PR pins GitHub Actions to SHA hashes instead of tags.